### PR TITLE
raise level to 1.8 from 1.6

### DIFF
--- a/javac-ast-extension/javac-ast-extension.iml
+++ b/javac-ast-extension/javac-ast-extension.iml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module type="JAVA_MODULE" version="4">
-  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_6" inherit-compiler-output="true">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" />
     </content>
-    <orderEntry type="jdk" jdkName="1.6" jdkType="JavaSDK" />
+    <orderEntry type="jdk" jdkName="1.8" jdkType="JavaSDK" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" name="org.jetbrains:annotations-java5:20.0.0" level="project" />
     <orderEntry type="library" name="it.unimi.dsi.fastutil" level="project" />

--- a/javac-ast-extension/src/org/jetbrains/jps/javac/ast/api/JavacFileData.java
+++ b/javac-ast-extension/src/org/jetbrains/jps/javac/ast/api/JavacFileData.java
@@ -108,7 +108,7 @@ public final class JavacFileData {
 
   private static Object2IntOpenHashMap<JavacRef> readRefs(final DataInput in) throws IOException {
     int size = in.readInt();
-    Object2IntOpenHashMap<JavacRef> deserialized = new Object2IntOpenHashMap<JavacRef>(size);
+    Object2IntOpenHashMap<JavacRef> deserialized = new Object2IntOpenHashMap<>(size);
     while (size-- > 0) {
       final JavacRef key = readJavacRef(in);
       final int value = in.readInt();
@@ -127,7 +127,7 @@ public final class JavacFileData {
 
   private static List<JavacDef> readDefs(final DataInput in) throws IOException {
     int size = in.readInt();
-    List<JavacDef> result = new ArrayList<JavacDef>(size);
+    List<JavacDef> result = new ArrayList<>(size);
     while (size-- > 0) {
       result.add(readJavacDef(in));
     }
@@ -246,14 +246,14 @@ public final class JavacFileData {
 
   private static Set<Modifier> readModifiers(final DataInput input) throws IOException {
     int size = input.readInt();
-    final List<Modifier> modifierList = new ArrayList<Modifier>(size);
+    final List<Modifier> modifierList = new ArrayList<>(size);
     while (size-- > 0) {
       modifierList.add(Modifier.valueOf(input.readUTF()));
     }
     return modifierList.isEmpty() ? Collections.<Modifier>emptySet() : EnumSet.copyOf(modifierList);
   }
 
-  private static void saveCasts(@NotNull final DataOutput output, @NotNull List<? extends JavacTypeCast> casts) throws IOException {
+  private static void saveCasts(@NotNull final DataOutput output, @NotNull List<JavacTypeCast> casts) throws IOException {
     output.writeInt(casts.size());
     for (JavacTypeCast cast : casts) {
       writeJavacRef(output, cast.getOperandType());
@@ -264,7 +264,7 @@ public final class JavacFileData {
   @NotNull
   private static List<JavacTypeCast> readCasts(@NotNull final DataInput input) throws IOException {
     int size = input.readInt();
-    List<JavacTypeCast> result = new ArrayList<JavacTypeCast>(size);
+    List<JavacTypeCast> result = new ArrayList<>(size);
     while (size-- > 0) {
       final JavacRef.JavacClass operandType = (JavacRef.JavacClass)readJavacRef(input);
       final JavacRef.JavacClass castType = (JavacRef.JavacClass)readJavacRef(input);
@@ -276,7 +276,7 @@ public final class JavacFileData {
   @NotNull
   private static Set<JavacRef> readImplicitToString(@NotNull DataInputStream in) throws IOException {
     int size = ((DataInput)in).readInt();
-    final Set<JavacRef> result = new HashSet<JavacRef>(size);
+    final Set<JavacRef> result = new HashSet<>(size);
     while (size-- > 0) {
       result.add(readJavacRef(in));
     }

--- a/javac-ast-extension/src/org/jetbrains/jps/javac/ast/api/JavacRef.java
+++ b/javac-ast-extension/src/org/jetbrains/jps/javac/ast/api/JavacRef.java
@@ -235,7 +235,7 @@ public interface JavacRef {
     }
     
     @Nullable
-    public static JavacElementRefBase fromElement(@Nullable String containigClass, Element element, Element qualifier, JavacNameTable nameTableCache, @Nullable ImportProperties importProps) {
+    public static JavacElementRefBase fromElement(@Nullable String containingClass, Element element, Element qualifier, JavacNameTable nameTableCache, @Nullable ImportProperties importProps) {
       if (qualifier != null) {
         TypeMirror type = qualifier.asType();
         if (!isValidType(type)) {
@@ -247,11 +247,11 @@ public interface JavacRef {
       }
       else if (element instanceof VariableElement) {
         if (qualifier == null && !checkEnclosingElement(element)) return null;
-        return new JavacElementFieldImpl(containigClass, element, qualifier, nameTableCache, importProps);
+        return new JavacElementFieldImpl(containingClass, element, qualifier, nameTableCache, importProps);
       }
       else if (element instanceof ExecutableElement) {
         if (qualifier == null && !checkEnclosingElement(element)) return null;
-        return new JavacElementMethodImpl(containigClass, element, qualifier, nameTableCache, importProps);
+        return new JavacElementMethodImpl(containingClass, element, qualifier, nameTableCache, importProps);
       }
       else if (element == null || element.getKind() == ElementKind.OTHER || element.getKind() == ElementKind.TYPE_PARAMETER) {
         // javac reserved symbol kind (e.g: com.sun.tools.javac.comp.Resolve.ResolveError)

--- a/javac-ref-scanner-8/javac-ref-scanner-8.iml
+++ b/javac-ref-scanner-8/javac-ref-scanner-8.iml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module type="JAVA_MODULE" version="4">
-  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_8" inherit-compiler-output="true">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" />


### PR DESCRIPTION
Please note - fastutil requires at least Java 8. And this functionality is optional—the compiler reference index may be disabled for old deprecated 1.6 JDK.